### PR TITLE
CI builds with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tvOS:
+    name: tvOS
+    runs-on: macOS-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: xcodebuild -project Wasserflug-tvOS.xcodeproj -scheme Wasserflug-tvOS -destination "generic/platform=tvOS Simulator"


### PR DESCRIPTION
Runs on GitHub hosted CI runners, free for open source projects.

Ensures that the tvOS build is successful for all future pushed commits and pull requests once merged in.

Can be extended with additional logic in the future as needed

- Run unit tests
- Fastlane for automatic uploads to TestFlight
- Additional clients such as the iOS PR

Example build: https://github.com/Dahlgren/Wasserflug-tvOS/actions/runs/3260664869