### PR TITLE
Added playback speed to the video player

### DIFF
--- a/Wasserflug-tvOS/SupplementalViews/VideoPlayerView.swift
+++ b/Wasserflug-tvOS/SupplementalViews/VideoPlayerView.swift
@@ -28,6 +28,8 @@ struct VideoPlayerView: UIViewControllerRepresentable {
 		])
 		let vc = AVPlayerViewController()
 		vc.delegate = context.coordinator
+		vc.speeds = viewModel.supportedSpeeds
+		vc.view.layoutIfNeeded() // This is needed or the OOTB speed controls don't display until you show the video for the second time
 		vc.transportBarCustomMenuItems = [createQualityAction()]
 		let playerItem = viewModel.createAVPlayerItem(desiredQuality: desiredQuality)
 		

--- a/Wasserflug-tvOS/ViewModels/VideoViewModel.swift
+++ b/Wasserflug-tvOS/ViewModels/VideoViewModel.swift
@@ -29,6 +29,14 @@ class VideoViewModel: BaseViewModel, ObservableObject {
 	let contentPost: ContentPostV3Response
 	let description: AttributedString
 	
+	let supportedSpeeds = [AVPlaybackSpeed(rate: 0.5, localizedName: "x0.5"),
+						   AVPlaybackSpeed(rate: 0.75, localizedName: "x0.75"),
+						   AVPlaybackSpeed(rate: 1.0, localizedName: "x1.0"),
+						   AVPlaybackSpeed(rate: 1.25, localizedName: "x1.25"),
+						   AVPlaybackSpeed(rate: 1.5, localizedName: "x1.5"),
+						   AVPlaybackSpeed(rate: 1.75, localizedName: "x1.75"),
+						   AVPlaybackSpeed(rate: 2.0, localizedName: "x2.0")]
+	
 	var avMetadataItems: [AVMetadataItem] {
 		let desc = String(description.characters)
 		


### PR DESCRIPTION
@Jman012 - I use this app quite a bit and figured I'd take a stab a quick win. Playback speed seemed like something I'd use, plus you have an enhancement logged for it. I noodled about adding the selected playback speed to UserDefaults like you're doing with resolution but thought it might be kind of annoying if I came back to the app after some time and wasn't expecting it.

I'm mainly a web developer so I may be doing something dumb here (particularly with the layoutIfNeeded call) but it's the only way I could get the control to show up the first time the playback controls are displayed.